### PR TITLE
Unify variable mapping

### DIFF
--- a/app_explorer.py
+++ b/app_explorer.py
@@ -5,11 +5,11 @@ from components.panels import panel_documentacion, panel_trayectoriasolar, panel
 from utils.data_processing import load_esolmet_data
 from utils.graficadores import graficado_Is_matplotlib
 #import plotly.express as px
-from utils.config import load_settings
 # import duckdb
+from utils.config import load_settings
 
 
-variables, latitude, longitude, gmt, name, alias = load_settings()
+variables, latitude, longitude, gmt, name = load_settings()
 # con = duckdb.connect('esolmet.db')
 
 #No voy a usar plotly por el momento hasta no tener idea de los datos

--- a/configuration.ini
+++ b/configuration.ini
@@ -1,18 +1,15 @@
 [settings]
-variables = ["I_dir_Avg","I_glo_Avg","I_dif_Avg","I_uv_Avg",
-            "AirTC_Avg","RH","WS_ms_Avg","WindDir","CS106_PB_Avg","Rain_mm_Tot"]
+variables = {"I_dir_Avg": "idir",
+             "I_glo_Avg": "iglo",
+             "I_dif_Avg": "idiff",
+             "I_uv_Avg": "uv",
+             "AirTC_Avg": "tdb",
+             "RH": "rh",
+             "WS_ms_Avg": "ws",
+             "WindDir": "wd",
+             "CS106_PB_Avg": "pres",
+             "Rain_mm_Tot": "rain"}
 latitude = 18.5
 longitude = -100
 gmt = -6
 name = Esolmet explorer
-
-alias = {"I_dir_Avg": "idir",
-        "I_glo_Avg": "iglo",
-        "I_dif_Avg": "idiff",
-        "I_uv_Avg": "uv",
-        "AirTC_Avg": "tdb",
-        "RH": "rh",
-        "WS_ms_Avg": "ws",
-        "WindDir": "wd",
-        "CS106_PB_Avg": "pres",
-        "Rain_mm_Tot": "rain"}

--- a/utils/config.py
+++ b/utils/config.py
@@ -4,7 +4,7 @@ import ast
 def load_settings(path: str = "configuration.ini"):
     """
     Lee el archivo INI y devuelve:
-      - variables: list[str]
+      - variables: dict[str, str]  # {col_original: col_nuevo}
       - latitude: float
       - longitude: float
       - gmt: int
@@ -14,13 +14,11 @@ def load_settings(path: str = "configuration.ini"):
     config.read(path)
 
     sec = config["settings"]
-    variables = ast.literal_eval(sec.get("variables", "[]"))
+    var_str   = sec.get("variables", "{}")
+    variables = ast.literal_eval(var_str)
     latitude  = sec.getfloat("latitude", fallback=0.0)
     longitude = sec.getfloat("longitude", fallback=0.0)
     gmt       = sec.getint("gmt", fallback=0)
     name      = sec.get("name", fallback="")
-    alias_str = sec.get("alias", "{}")
-    alias     = ast.literal_eval(alias_str)
-
-    return variables, latitude, longitude, gmt, name, alias
+    return variables, latitude, longitude, gmt, name
 

--- a/utils/data_processing.py
+++ b/utils/data_processing.py
@@ -3,8 +3,8 @@ import validation_tools as vt
 from utils.config import load_settings
 import glob
 
-variables, latitude, longitude, gmt, name, alias = load_settings()
-ALLOWED_VARS = variables
+variables, latitude, longitude, gmt, name = load_settings()
+ALLOWED_VARS = list(variables.keys())
 MIN_YEAR = 2010
 
 
@@ -125,9 +125,9 @@ def export_data(filepath: str) -> pd.DataFrame:
     # 1. cargar y limpiar
     df = load_csv(filepath, sort=False)
 
-    # 2. renombrar columnas según alias definido en configuration.ini
-    if alias:
-        df.rename(columns=alias, inplace=True)
+    # 2. renombrar columnas según los nombres configurados
+    if variables:
+        df.rename(columns=variables, inplace=True)
 
     # 3. convertir la fecha a string
     df['TIMESTAMP'] = df['TIMESTAMP'].dt.strftime('%Y-%m-%d %H:%M')

--- a/utils/graficadores.py
+++ b/utils/graficadores.py
@@ -6,7 +6,8 @@ from matplotlib.gridspec import GridSpec
 from utils.config import load_settings
 
 
-variables, _, _, _, _, names = load_settings()
+variables, _, _, _, _ = load_settings()
+names = variables
 con = duckdb.connect('esolmet.db')
 
 def graficado_Is_matplotlib(fechas):

--- a/validation_tools/main.py
+++ b/validation_tools/main.py
@@ -133,7 +133,8 @@ def detect_radiation(df: pd.DataFrame, config_path: str = "configuration.ini") -
             - radiation_ok (bool): True if no positive radiation values occur
               when solar_altitude ≤ 0; False otherwise.
     """
-    vars_list, lat, lon, gmt, name, alias = load_settings(config_path)
+    vars_dict, lat, lon, gmt, name = load_settings(config_path)
+    vars_list = list(vars_dict.keys())
 
     # 1) generar tz a partir de gmt
     inv = -gmt


### PR DESCRIPTION
## Summary
- store variable name mapping in `configuration.ini`
- parse new mapping in `load_settings`
- update data processing utilities for new dictionary
- adapt visualization and validation modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f4bbd5d84832d9ef50b28b649fd94